### PR TITLE
Adds support for downloading GitHub releases

### DIFF
--- a/api/DownloadContent/index.js
+++ b/api/DownloadContent/index.js
@@ -13,6 +13,8 @@ module.exports = async function download(context, req) {
       // if the url is a youtube url
       if (downloadUrl.includes('youtube') || downloadUrl.includes('youtu.be')) {
         result = await downloadService.downloadYouTubeCaptions(downloadUrl)
+      } else if (downloadUrl.includes('github.com') && downloadUrl.includes('/releases/')) {
+        result = await downloadService.downloadGitHubRelease(downloadUrl)
       } else {
         // otherwise we assume its a webpage and try to download the text
         result = await downloadService.downloadWebPageText(downloadUrl)

--- a/api/services/downloadService.js
+++ b/api/services/downloadService.js
@@ -48,6 +48,24 @@ const downloadService = {
     } catch (error) {
       return { status: 500, body: error.message }
     }
+  },
+
+  downloadGitHubRelease: async (url) => {
+    try {
+      const response = await fetch(url)
+      const html = await response.text()
+      const dom = new JSDOM(html);
+
+      const releaseName = getGitHubReleaseTitle(dom);
+      const relatedIssuesUrl = getRelatedGitHubIssuesUrls(dom);
+      const relatedIssues = await getRelatedGitHubIssues(relatedIssuesUrl);
+      const gitHubReleaseHtml = buildGitHubReleaseHtml(releaseName, relatedIssues);
+
+      return { status: 200, body: { type: 'webpage', content: gitHubReleaseHtml } }
+    }
+    catch (error) {
+      return { status: 500, body: error.message }
+    }
   }
 }
 
@@ -63,6 +81,57 @@ function formatTime(seconds) {
   const formattedMinutes = String(minutes).padStart(2, '0')
   const formattedSeconds = String(remainingSeconds).padStart(2, '0')
   return `${formattedMinutes}:${formattedSeconds}`
+}
+
+function getGitHubReleaseTitle(dom) {
+  return dom.window.document.querySelector('#repo-content-turbo-frame h1').textContent;
+}
+
+function getRelatedGitHubIssuesUrls(dom) {
+  const releaseBodyElement = dom.window.document.querySelector('#repo-content-turbo-frame [data-test-selector="body-content"]');
+    const links = releaseBodyElement.querySelectorAll('a.issue-link');
+    const linkedIssuesUrls = [];
+    links.forEach(link => {
+        const href = link.getAttribute('href');
+        if (href.indexOf('/issues/') > -1) {
+            linkedIssuesUrls.push(href);
+        }
+    });
+    return linkedIssuesUrls;
+}
+
+async function getRelatedGitHubIssues(issuesUrls) {
+  const issues = await Promise.all(issuesUrls.map(async url => {
+    const response = await fetch(url)
+    const html = await response.text()
+    const dom = new JSDOM(html);
+    const title = dom.window.document.querySelector('#partial-discussion-header .js-issue-title').textContent;
+        const body = dom.window.document.querySelector('.js-comment-body').textContent;
+    return {
+      title,
+      body
+    };
+  }));
+  return issues;
+}
+
+function buildGitHubReleaseHtml(releaseName, issues) {
+  const html = `
+<html>
+<head>
+  <title>${releaseName}</title>
+</head>
+<body>
+<h1>${releaseName}</h1>
+
+${issues.map(issue => `
+<h2>${issue.title}</h2>
+<p>${issue.body}</p>
+`)}
+</body>
+</html>
+  `;
+  return html;
 }
 
 module.exports = downloadService


### PR DESCRIPTION
- extends the downloadService with the ability to download the contents of a GitHub release and pull in content of the referenced issues
- extends the DownloadContent api with detecting GitHub release URLs